### PR TITLE
お気に入りボタンを押した時の触覚フィードバックの追加

### DIFF
--- a/Osushi/View/PostList/DetailPostView.swift
+++ b/Osushi/View/PostList/DetailPostView.swift
@@ -39,7 +39,7 @@ struct DetailPostView: View {
                         tappedFavoriteButton()
                     }
                     .popoverTip(FavoriteButtonTip())
-                    .sensoryFeedback(.impact(weight: .light), trigger: isFavorited) { _, new in
+.sensoryFeedback(.impact, trigger: isFavorited)
                         new == true
                     }
             }

--- a/Osushi/View/PostList/DetailPostView.swift
+++ b/Osushi/View/PostList/DetailPostView.swift
@@ -39,9 +39,7 @@ struct DetailPostView: View {
                         tappedFavoriteButton()
                     }
                     .popoverTip(FavoriteButtonTip())
-.sensoryFeedback(.impact, trigger: isFavorited)
-                        new == true
-                    }
+                    .sensoryFeedback(.impact, trigger: isFavorited)
             }
         }
         .task {

--- a/Osushi/View/PostList/DetailPostView.swift
+++ b/Osushi/View/PostList/DetailPostView.swift
@@ -39,6 +39,9 @@ struct DetailPostView: View {
                         tappedFavoriteButton()
                     }
                     .popoverTip(FavoriteButtonTip())
+                    .sensoryFeedback(.impact(weight: .light), trigger: isFavorited) { _, new in
+                        new == true
+                    }
             }
         }
         .task {


### PR DESCRIPTION
# Issue

Close #14 

# 対応した内容

- お気に入りボタンを押した時に触覚フィードバックを追加しました。
	- [こちらの記事](https://qiita.com/yoshitaka/items/6620b87b0ebe6b0ab01d#%E3%81%84%E3%81%84%E3%81%AD%E3%83%9C%E3%82%BF%E3%83%B3%E3%82%92%E3%82%BF%E3%83%83%E3%83%97%E3%81%97%E3%81%9F%E6%99%82%E3%81%AB%E3%83%88%E3%83%AA%E3%82%AC%E3%83%BC%E3%81%99%E3%82%8B%E6%96%B9%E6%B3%95)を参考に、iOS 17以降で使用できる`sensoryFeedback`を使用しました。
	- 触覚フィードバックの種類は`.impact(weight: .light)`を設定していますが、実機で起動できず動作を確認できていないので、お手数ですが、触覚フィードバックの種類や動作で気になる点があれば教えてくださいmm

# Note

- レビュアーへの参考情報、実装上の懸念点や注意点
- バグ対応であれば、バグの再現手順
