### PR TITLE
smart-markdown-uiライブラリのバージョンを2.3.0から2.4.1に更新

### DIFF
--- a/Osushi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Osushi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,12 +11,21 @@
       }
     },
     {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark",
+      "state" : {
+        "revision" : "3ccff77b2dc5b96b77db3da0d68d28068593fa53",
+        "version" : "0.5.0"
+      }
+    },
+    {
       "identity" : "swift-markdown-ui",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gonzalezreal/swift-markdown-ui",
       "state" : {
-        "revision" : "ae799d015a5374708f7b4c85f3294c05f2a564e2",
-        "version" : "2.3.0"
+        "revision" : "5f613358148239d0292c0cef674a3c2314737f9e",
+        "version" : "2.4.1"
       }
     }
   ],


### PR DESCRIPTION
# Issue

Close #18

# 対応した内容
- issue記載のエラーを解決するためにswift-markdown-uiライブラリのバージョンを2.3.0→2.4.1に更新
  - swift-markdown-uiライブラリの更新に伴い、swift-cmarkも追加された

# 確認事項
ビルド確認までできています。

# Note
- 【参考】swift-markdown-uiリポジトリ2.4.0にて下記のissueが解決されたため、2.4.0以上に更新
[Circular Reference Compilation Error when Compiling with Xcode 6.0 Beta Tools #323](https://github.com/gonzalezreal/swift-markdown-ui/issues/323)